### PR TITLE
Feat/add-more-pdus

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4,6 +4,7 @@ import {
     BindReceiverParams,
     BindTransceiverParams,
     BindTransmitterParams,
+    CancelSmParams,
     CommandClient,
     DataSmParams,
     InterfaceVersion,
@@ -84,6 +85,7 @@ export default class Client {
         this.session.on(eventName, callback);
     }
 
+    // TODO: Add description for each function
     bindTransceiver(params: BindTransceiverParams): boolean {
         return this.session.bindTransceiver(params);
     }
@@ -106,6 +108,10 @@ export default class Client {
 
     querySm(params: QuerySmParams): boolean {
         return this.session.querySm(params);
+    }
+
+    cancelSm(params: CancelSmParams): boolean {
+        return this.session.cancelSm(params);
     }
 
     enquireLink(): boolean {

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,7 @@ import {
     DataSmParams,
     InterfaceVersion,
     QuerySmParams,
+    ReplaceSmParams,
     SubmitSmParams,
 } from './types';
 
@@ -112,6 +113,10 @@ export default class Client {
 
     cancelSm(params: CancelSmParams): boolean {
         return this.session.cancelSm(params);
+    }
+
+    replaceSm(params: ReplaceSmParams): boolean {
+        return this.session.replaceSm(params);
     }
 
     enquireLink(): boolean {

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,6 +11,7 @@ import {
     QuerySmParams,
     ReplaceSmParams,
     SubmitSmParams,
+    DeliverSmRespParams,
 } from './types';
 
 export default class Client {
@@ -117,6 +118,10 @@ export default class Client {
 
     replaceSm(params: ReplaceSmParams): boolean {
         return this.session.replaceSm(params);
+    }
+
+    deliverSmResp(params: DeliverSmRespParams): boolean {
+        return this.session.deliverSmResp(params);
     }
 
     enquireLink(): boolean {

--- a/src/constains/encodes.ts
+++ b/src/constains/encodes.ts
@@ -1,0 +1,41 @@
+import { Encode } from '../types';
+
+/**
+ * SMPP data_coding values to Buffer encoding mapping
+ *
+ * TODO: Some encodes are as fallback, new encodes will be implemented in the future.
+ *
+ * ref: Documentation SMPP_v5 - 4.7.7 data_coding
+ */
+const encodesName: Record<number, Encode> = {
+    0: 'ascii', // GSM 7-bit Default Alphabet (GSM 03.38)
+    1: 'ascii', // IA5 (CCITT T.50)/ASCII (ANSI X3.4)
+    2: 'latin1', // Octet unspecified (8-bit binary)
+    3: 'latin1', // Latin 1 (ISO-8859-1)
+    4: 'latin1', // Octet unspecified (8-bit binary)
+    5: 'ascii', // JIS (X 0208-1990) - fallback to ASCII
+    6: 'latin1', // Cyrillic (ISO-8859-5) - fallback to latin1
+    7: 'latin1', // Latin/Hebrew (ISO-8859-8) - fallback to latin1
+    8: 'ucs2', // UCS2 (ISO/IEC-10646) - Unicode
+    9: 'latin1', // Pictogram Encoding - fallback to latin1
+    10: 'ascii', // ISO-2022-JP (Music Codes) - fallback to ASCII
+    13: 'ascii', // Extended Kanji JIS (X 0212-1990) - fallback to ASCII
+    14: 'latin1', // KS C 5601 (Korean) - fallback to latin1
+
+    // Flash SMS values, same encoding as base value but with 240 value.
+    240: 'ascii', // Flash + GSM 7-bit
+    241: 'ascii', // Flash + IA5/ASCII
+    242: 'latin1', // Flash + Octet unspecified
+    243: 'latin1', // Flash + Latin 1
+    244: 'latin1', // Flash + Octet unspecified
+    245: 'ascii', // Flash + JIS
+    246: 'latin1', // Flash + Cyrillic
+    247: 'latin1', // Flash + Latin/Hebrew
+    248: 'ucs2', // Flash + UCS2
+    249: 'latin1', // Flash + Pictogram
+    250: 'ascii', // Flash + ISO-2022-JP
+    253: 'ascii', // Flash + Extended Kanji JIS
+    254: 'latin1', // Flash + KS C 5601
+};
+
+export { encodesName };

--- a/src/constains/index.ts
+++ b/src/constains/index.ts
@@ -1,3 +1,4 @@
 export * from './commandsId';
 export * from './optionalParams';
 export * from './commandStatus';
+export * from './encodes';

--- a/src/dtos/cancel_sm.ts
+++ b/src/dtos/cancel_sm.ts
@@ -1,0 +1,36 @@
+import { CancelSm, CancelSmFunction, CancelSmParams } from '../types';
+import { dtoValidation } from '../helpers';
+
+const MAX_LENGTH: Record<string, number> = {
+    message_id: 65,
+    service_type: 6,
+    source_addr: 21,
+    destination_addr: 21,
+};
+
+export const cancelSmDTO: CancelSmFunction = ({
+    destinationAddr,
+    messageId,
+    systemTypeValue,
+    sourceAddrTon,
+    sourceAddrNpi,
+    sourceAddr,
+    destAddrTon,
+    destAddrNpi,
+}: CancelSmParams): CancelSm => {
+    const dto: CancelSm = {
+        command: {
+            service_type: { type: 'Cstring', value: systemTypeValue || '' },
+            message_id: { type: 'Cstring', value: messageId },
+            source_addr_ton: { type: 'Int8', value: sourceAddrTon || 0 },
+            source_addr_npi: { type: 'Int8', value: sourceAddrNpi || 0 },
+            source_addr: { type: 'Cstring', value: sourceAddr || '' },
+            dest_addr_ton: { type: 'Int8', value: destAddrTon || 0 },
+            dest_addr_npi: { type: 'Int8', value: destAddrNpi || 0 },
+            destination_addr: { type: 'Cstring', value: destinationAddr },
+        },
+    };
+
+    dtoValidation({ dto, MAX_LENGTH });
+    return dto;
+};

--- a/src/dtos/cancel_sm_resp.ts
+++ b/src/dtos/cancel_sm_resp.ts
@@ -1,0 +1,8 @@
+import { CancelSmResp, CancelSmRespFunction } from '../types';
+
+export const cancelSmRespDTO: CancelSmRespFunction = (): CancelSmResp => {
+    return {
+        command: {},
+        tlvs: {},
+    };
+};

--- a/src/dtos/deliver_sm.ts
+++ b/src/dtos/deliver_sm.ts
@@ -1,0 +1,48 @@
+import { DeliverSm, DeliverSmFunction, DeliverSmParams } from '../types';
+
+export const deliverSmDTO: DeliverSmFunction = ({
+    destinationAddr,
+    dataCoding,
+    esmClass,
+    systemTypeValue,
+    sourceAddrTon,
+    sourceAddrNpi,
+    sourceAddr,
+    destAddrTon,
+    destAddrNpi,
+    protocolId,
+    priorityFlag,
+    scheduleDeliveryTime,
+    validityPeriod,
+    registeredDelivery,
+    replaceIfPresentFlag,
+    smDefaultMsgId,
+    shortMessage,
+    smLength,
+}: DeliverSmParams): DeliverSm => {
+    return {
+        command: {
+            service_type: { type: 'Cstring', value: systemTypeValue || '' },
+            source_addr_ton: { type: 'Int8', value: sourceAddrTon || 0 },
+            source_addr_npi: { type: 'Int8', value: sourceAddrNpi || 0 },
+            source_addr: { type: 'Cstring', value: sourceAddr || '' },
+            dest_addr_ton: { type: 'Int8', value: destAddrTon || 0 },
+            dest_addr_npi: { type: 'Int8', value: destAddrNpi || 0 },
+            destination_addr: { type: 'Cstring', value: destinationAddr },
+            esm_class: { type: 'Int8', value: esmClass },
+            protocol_id: { type: 'Int8', value: protocolId || 0 },
+            priority_flag: { type: 'Int8', value: priorityFlag || 0 },
+            schedule_delivery_time: { type: 'Cstring', value: scheduleDeliveryTime || '' },
+            validity_period: { type: 'Cstring', value: validityPeriod || '' },
+            registered_delivery: { type: 'Int8', value: registeredDelivery || 0 },
+            replace_if_present_flag: { type: 'Int8', value: replaceIfPresentFlag || 0 },
+            data_coding: { type: 'Int8', value: dataCoding },
+            sm_default_msg_id: { type: 'Int8', value: smDefaultMsgId || 0 },
+            sm_length: { type: 'Int8', value: smLength || 0 },
+            short_message: {
+                type: 'Cstring',
+                value: shortMessage?.message || '',
+            },
+        },
+    };
+};

--- a/src/dtos/deliver_sm_resp.ts
+++ b/src/dtos/deliver_sm_resp.ts
@@ -1,0 +1,17 @@
+import { DeliverSmResp, DeliverSmRespFunction, DeliverSmRespParams } from '../types';
+import { dtoValidation } from '../helpers';
+
+const MAX_LENGTH: Record<string, number> = {
+    message_id: 65,
+};
+
+export const deliverSmRespDTO: DeliverSmRespFunction = ({ messageId }: DeliverSmRespParams): DeliverSmResp => {
+    const dto: DeliverSmResp = {
+        command: {
+            message_id: { type: 'Cstring', value: messageId || '' },
+        },
+    };
+
+    dtoValidation({ dto, MAX_LENGTH });
+    return dto;
+};

--- a/src/dtos/index.ts
+++ b/src/dtos/index.ts
@@ -10,6 +10,7 @@ import {
     CancelSmFunction,
     ReplaceSmFunction,
     DeliverSmFunction,
+    DeliverSmRespFunction,
 } from '../types';
 import { bindTransceiverDTO } from './bind_transceiver';
 import { bindTransceiverRespDTO } from './bind_transceiver_resp';
@@ -32,6 +33,7 @@ import { cancelSmRespDTO } from './cancel_sm_resp';
 import { outbindDTO } from './outbind';
 import { replaceSmDTO } from './replace_sm';
 import { deliverSmDTO } from './deliver_sm';
+import { deliverSmRespDTO } from './deliver_sm_resp';
 
 const DTOs: Record<string, DTOFunction<never, DTO>> = {
     bind_transceiver: bindTransceiverDTO,
@@ -55,6 +57,7 @@ const DTOs: Record<string, DTOFunction<never, DTO>> = {
     outbind: outbindDTO,
     replace_sm: replaceSmDTO,
     deliver_sm: deliverSmDTO,
+    deliver_sm_resp: deliverSmRespDTO,
 };
 
 const getDTO = <
@@ -68,7 +71,8 @@ const getDTO = <
         | QuerySmFunction
         | CancelSmFunction
         | ReplaceSmFunction
-        | DeliverSmFunction,
+        | DeliverSmFunction
+        | DeliverSmRespFunction,
 >(
     name: string,
 ): T => {

--- a/src/dtos/index.ts
+++ b/src/dtos/index.ts
@@ -9,6 +9,7 @@ import {
     QuerySmFunction,
     CancelSmFunction,
     ReplaceSmFunction,
+    DeliverSmFunction,
 } from '../types';
 import { bindTransceiverDTO } from './bind_transceiver';
 import { bindTransceiverRespDTO } from './bind_transceiver_resp';
@@ -30,6 +31,7 @@ import { cancelSmDTO } from './cancel_sm';
 import { cancelSmRespDTO } from './cancel_sm_resp';
 import { outbindDTO } from './outbind';
 import { replaceSmDTO } from './replace_sm';
+import { deliverSmDTO } from './deliver_sm';
 
 const DTOs: Record<string, DTOFunction<never, DTO>> = {
     bind_transceiver: bindTransceiverDTO,
@@ -52,6 +54,7 @@ const DTOs: Record<string, DTOFunction<never, DTO>> = {
     cancel_sm_resp: cancelSmRespDTO,
     outbind: outbindDTO,
     replace_sm: replaceSmDTO,
+    deliver_sm: deliverSmDTO,
 };
 
 const getDTO = <
@@ -64,7 +67,8 @@ const getDTO = <
         | DataSmFunction
         | QuerySmFunction
         | CancelSmFunction
-        | ReplaceSmFunction,
+        | ReplaceSmFunction
+        | DeliverSmFunction,
 >(
     name: string,
 ): T => {

--- a/src/dtos/index.ts
+++ b/src/dtos/index.ts
@@ -7,6 +7,7 @@ import {
     EnquireLinkFunction,
     DataSmFunction,
     QuerySmFunction,
+    CancelSmFunction,
 } from '../types';
 import { bindTransceiverDTO } from './bind_transceiver';
 import { bindTransceiverRespDTO } from './bind_transceiver_resp';
@@ -24,6 +25,8 @@ import { dataSmDTO } from './data_sm';
 import { dataSmRespDTO } from './data_sm_resp';
 import { querySmDTO } from './query_sm';
 import { querySmRespDTO } from './query_sm_resp';
+import { cancelSmDTO } from './cancel_sm';
+import { cancelSmRespDTO } from './cancel_sm_resp';
 
 const DTOs: Record<string, DTOFunction<never, DTO>> = {
     bind_transceiver: bindTransceiverDTO,
@@ -42,10 +45,20 @@ const DTOs: Record<string, DTOFunction<never, DTO>> = {
     data_sm_resp: dataSmRespDTO,
     query_sm: querySmDTO,
     query_sm_resp: querySmRespDTO,
+    cancel_sm: cancelSmDTO,
+    cancel_sm_resp: cancelSmRespDTO,
 };
 
 const getDTO = <
-    T extends DTOFunction | BindTransceiverFunction | BindTransceiverRespFunction | SubmitSmFunction | EnquireLinkFunction | DataSmFunction | QuerySmFunction,
+    T extends
+        | DTOFunction
+        | BindTransceiverFunction
+        | BindTransceiverRespFunction
+        | SubmitSmFunction
+        | EnquireLinkFunction
+        | DataSmFunction
+        | QuerySmFunction
+        | CancelSmFunction,
 >(
     name: string,
 ): T => {

--- a/src/dtos/index.ts
+++ b/src/dtos/index.ts
@@ -8,6 +8,7 @@ import {
     DataSmFunction,
     QuerySmFunction,
     CancelSmFunction,
+    ReplaceSmFunction,
 } from '../types';
 import { bindTransceiverDTO } from './bind_transceiver';
 import { bindTransceiverRespDTO } from './bind_transceiver_resp';
@@ -28,6 +29,7 @@ import { querySmRespDTO } from './query_sm_resp';
 import { cancelSmDTO } from './cancel_sm';
 import { cancelSmRespDTO } from './cancel_sm_resp';
 import { outbindDTO } from './outbind';
+import { replaceSmDTO } from './replace_sm';
 
 const DTOs: Record<string, DTOFunction<never, DTO>> = {
     bind_transceiver: bindTransceiverDTO,
@@ -49,6 +51,7 @@ const DTOs: Record<string, DTOFunction<never, DTO>> = {
     cancel_sm: cancelSmDTO,
     cancel_sm_resp: cancelSmRespDTO,
     outbind: outbindDTO,
+    replace_sm: replaceSmDTO,
 };
 
 const getDTO = <
@@ -60,7 +63,8 @@ const getDTO = <
         | EnquireLinkFunction
         | DataSmFunction
         | QuerySmFunction
-        | CancelSmFunction,
+        | CancelSmFunction
+        | ReplaceSmFunction,
 >(
     name: string,
 ): T => {

--- a/src/dtos/index.ts
+++ b/src/dtos/index.ts
@@ -27,6 +27,7 @@ import { querySmDTO } from './query_sm';
 import { querySmRespDTO } from './query_sm_resp';
 import { cancelSmDTO } from './cancel_sm';
 import { cancelSmRespDTO } from './cancel_sm_resp';
+import { outbindDTO } from './outbind';
 
 const DTOs: Record<string, DTOFunction<never, DTO>> = {
     bind_transceiver: bindTransceiverDTO,
@@ -47,6 +48,7 @@ const DTOs: Record<string, DTOFunction<never, DTO>> = {
     query_sm_resp: querySmRespDTO,
     cancel_sm: cancelSmDTO,
     cancel_sm_resp: cancelSmRespDTO,
+    outbind: outbindDTO,
 };
 
 const getDTO = <

--- a/src/dtos/outbind.ts
+++ b/src/dtos/outbind.ts
@@ -1,0 +1,10 @@
+import { OutbindParams, Outbind, OutbindFunction } from '../types';
+
+export const outbindDTO: OutbindFunction = ({ systemId, password }: OutbindParams): Outbind => {
+    return {
+        command: {
+            system_id: { type: 'Cstring', value: systemId },
+            password: { type: 'Cstring', value: password },
+        },
+    };
+};

--- a/src/dtos/replace_sm.ts
+++ b/src/dtos/replace_sm.ts
@@ -1,0 +1,50 @@
+import { dateToAbsolute } from '../helpers';
+import { DateType, ReplaceSm, ReplaceSmFunction, ReplaceSmParams } from '../types';
+import { dtoValidation } from '../helpers';
+
+const MAX_LENGTH: Record<string, number> = {
+    source_addr: 21,
+    short_message: 256,
+    /* Dates */
+    schedule_delivery_time: 17,
+    validity_period: 17,
+};
+
+const DATE_TYPE = {
+    schedule_delivery_time: DateType.ABSOLUTE_AND_RELATIVE,
+    validity_period: DateType.ABSOLUTE_AND_RELATIVE,
+};
+
+export const replaceSmDTO: ReplaceSmFunction = ({
+    messageId,
+    sourceAddrTon,
+    sourceAddrNpi,
+    sourceAddr,
+    scheduleDeliveryTime,
+    validityPeriod,
+    registeredDelivery,
+    smDefaultMsgId,
+    shortMessage,
+}: ReplaceSmParams): ReplaceSm => {
+    const dto: ReplaceSm = {
+        command: {
+            message_id: { type: 'Cstring', value: messageId },
+            source_addr_ton: { type: 'Int8', value: sourceAddrTon || 0 },
+            source_addr_npi: { type: 'Int8', value: sourceAddrNpi || 0 },
+            source_addr: { type: 'Cstring', value: sourceAddr || '' },
+            schedule_delivery_time: { type: 'Cstring', value: scheduleDeliveryTime ? dateToAbsolute(scheduleDeliveryTime) : '' },
+            validity_period: { type: 'Cstring', value: validityPeriod ? dateToAbsolute(validityPeriod) : '' },
+            registered_delivery: { type: 'Int8', value: registeredDelivery || 0 },
+            sm_default_msg_id: { type: 'Int8', value: smDefaultMsgId || 0 },
+            short_message: {
+                type: 'Cstring',
+                value: shortMessage?.message || Buffer.alloc(0, '', shortMessage?.encoding as BufferEncoding),
+                encode: shortMessage?.encoding,
+                setLength: true,
+            },
+        },
+    };
+
+    dtoValidation({ dto, DATE_TYPE, MAX_LENGTH });
+    return dto;
+};

--- a/src/octets/cstring.ts
+++ b/src/octets/cstring.ts
@@ -54,21 +54,25 @@ class Cstring {
     /**
      * Read a cstring buffer and returns it in string
      */
-    static read({ buffer, offset }: { buffer: Buffer; offset: number }): string {
-        const MAX_SCAN = 16;
-        let length = 0;
-
-        while (length < MAX_SCAN && offset + length < buffer.length && buffer[offset + length]) {
-            length++;
+    static read({ buffer, offset, encoding = 'ascii', length }: { buffer: Buffer; offset: number; encoding?: Encode; length?: number }): string {
+        if (length && length > 0) {
+            return buffer.toString(encoding, offset, offset + length);
         }
 
-        if (length < MAX_SCAN || offset + length >= buffer.length) {
-            return buffer.toString('ascii', offset, offset + length);
+        const MAX_SCAN = 16;
+        let scanLength = 0;
+
+        while (scanLength < MAX_SCAN && offset + scanLength < buffer.length && buffer[offset + scanLength]) {
+            scanLength++;
+        }
+
+        if (scanLength < MAX_SCAN || offset + scanLength >= buffer.length) {
+            return buffer.toString(encoding, offset, offset + scanLength);
         }
 
         const nullIndex = buffer.indexOf(0, offset);
         const endIndex = nullIndex === -1 ? buffer.length : nullIndex;
-        return buffer.toString('ascii', offset, endIndex);
+        return buffer.toString(encoding, offset, endIndex);
     }
 
     /**

--- a/src/session.ts
+++ b/src/session.ts
@@ -24,6 +24,8 @@ import {
     CancelSmFunction,
     ReplaceSmFunction,
     ReplaceSmParams,
+    DeliverSmRespFunction,
+    DeliverSmRespParams,
 } from './types';
 
 export default class Session {
@@ -83,6 +85,7 @@ export default class Session {
                 if (data) {
                     const pdu = this.PDU.readPdu(data);
                     this.socket.emit('pdu', pdu);
+                    // TODO: Called debug log callback for each command
                 }
             } catch (error) {
                 this.socket.emit('error', error);
@@ -201,5 +204,13 @@ export default class Session {
         const dto = getDTO<UnbindFunction>('unbind')({});
         this.sequenceNumber += 1;
         return this.PDU.call({ command: 'unbind', sequenceNumber: this.sequenceNumber, dto });
+    }
+
+    deliverSmResp(params: DeliverSmRespParams): boolean {
+        this.logger.debug(`deliverSmResp - called`, params);
+
+        const dto = getDTO<DeliverSmRespFunction>('deliver_sm_resp')(params);
+        this.sequenceNumber += 1;
+        return this.PDU.call({ command: 'deliver_sm_resp', sequenceNumber: this.sequenceNumber, dto });
     }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -20,6 +20,8 @@ import {
     DataSmFunction,
     QuerySmParams,
     QuerySmFunction,
+    CancelSmParams,
+    CancelSmFunction,
 } from './types';
 
 export default class Session {
@@ -165,6 +167,14 @@ export default class Session {
         const dto = getDTO<QuerySmFunction>('query_sm')(params);
         this.sequenceNumber += 1;
         return this.PDU.call({ command: 'query_sm', sequenceNumber: this.sequenceNumber, dto });
+    }
+
+    cancelSm(params: CancelSmParams): boolean {
+        this.logger.debug(`cancelSm - called`, params);
+
+        const dto = getDTO<CancelSmFunction>('cancel_sm')(params);
+        this.sequenceNumber += 1;
+        return this.PDU.call({ command: 'cancel_sm', sequenceNumber: this.sequenceNumber, dto });
     }
 
     enquireLink(): boolean {

--- a/src/session.ts
+++ b/src/session.ts
@@ -22,6 +22,8 @@ import {
     QuerySmFunction,
     CancelSmParams,
     CancelSmFunction,
+    ReplaceSmFunction,
+    ReplaceSmParams,
 } from './types';
 
 export default class Session {
@@ -175,6 +177,14 @@ export default class Session {
         const dto = getDTO<CancelSmFunction>('cancel_sm')(params);
         this.sequenceNumber += 1;
         return this.PDU.call({ command: 'cancel_sm', sequenceNumber: this.sequenceNumber, dto });
+    }
+
+    replaceSm(params: ReplaceSmParams): boolean {
+        this.logger.debug(`replaceSm - called`, params);
+
+        const dto = getDTO<ReplaceSmFunction>('replace_sm')(params);
+        this.sequenceNumber += 1;
+        return this.PDU.call({ command: 'replace_sm', sequenceNumber: this.sequenceNumber, dto });
     }
 
     enquireLink(): boolean {

--- a/src/types/dto/cancel_sm.ts
+++ b/src/types/dto/cancel_sm.ts
@@ -1,0 +1,29 @@
+import { DTO, DTOFunction, SystemType } from '../index';
+
+export interface CancelSm extends DTO {
+    command: {
+        service_type: { type: 'Cstring'; value: SystemType | (string & {}) };
+        message_id: { type: 'Cstring'; value: string };
+        source_addr_ton: { type: 'Int8'; value: number };
+        source_addr_npi: { type: 'Int8'; value: number };
+        source_addr: { type: 'Cstring'; value: string };
+        dest_addr_ton: { type: 'Int8'; value: number };
+        dest_addr_npi: { type: 'Int8'; value: number };
+        destination_addr: { type: 'Cstring'; value: string };
+    };
+}
+
+export type CancelSmParams = {
+    messageId: string;
+    destinationAddr: string;
+    systemTypeValue?: SystemType | (string & {});
+    sourceAddrTon?: number;
+    sourceAddrNpi?: number;
+    sourceAddr?: string;
+    destAddrTon?: number;
+    destAddrNpi?: number;
+};
+
+export interface CancelSmFunction extends DTOFunction<CancelSmParams, CancelSm> {
+    ({ systemTypeValue, messageId, sourceAddrTon, sourceAddrNpi, sourceAddr, destAddrTon, destAddrNpi, destinationAddr }: CancelSmParams): CancelSm;
+}

--- a/src/types/dto/cancel_sm_resp.ts
+++ b/src/types/dto/cancel_sm_resp.ts
@@ -1,0 +1,9 @@
+import { DTO, DTOFunction } from '../index';
+
+export type CancelSmResp = DTO;
+
+export type CancelSmRespParams = unknown;
+
+export interface CancelSmRespFunction extends DTOFunction<CancelSmRespParams, CancelSmResp> {
+    (): CancelSmResp;
+}

--- a/src/types/dto/deliver_sm.ts
+++ b/src/types/dto/deliver_sm.ts
@@ -1,0 +1,74 @@
+import { DTO, DTOFunction, Encode, PriorityFlag, SystemType } from '../index';
+
+export interface DeliverSm extends DTO {
+    command: {
+        service_type: { type: 'Cstring'; value: SystemType | (string & {}) };
+        source_addr_ton: { type: 'Int8'; value: number };
+        source_addr_npi: { type: 'Int8'; value: number };
+        source_addr: { type: 'Cstring'; value: string };
+        dest_addr_ton: { type: 'Int8'; value: number };
+        dest_addr_npi: { type: 'Int8'; value: number };
+        destination_addr: { type: 'Cstring'; value: string };
+        esm_class: { type: 'Int8'; value: number };
+        protocol_id: { type: 'Int8'; value: number };
+        priority_flag: { type: 'Int8'; value: number };
+        schedule_delivery_time: { type: 'Cstring'; value: string };
+        validity_period: { type: 'Cstring'; value: string };
+        registered_delivery: { type: 'Int8'; value: number };
+        replace_if_present_flag: { type: 'Int8'; value: number };
+        data_coding: { type: 'Int8'; value: number };
+        sm_default_msg_id: { type: 'Int8'; value: number };
+        sm_length: { type: 'Int8'; value: number };
+        /**
+         * Default ASCII
+         */
+        short_message: { type: 'Cstring'; value: string | Buffer; encode?: Encode };
+    };
+}
+
+export type DeliverSmParams = {
+    destinationAddr: string;
+    dataCoding: number;
+    esmClass: number;
+    systemTypeValue?: SystemType | (string & {});
+    sourceAddrTon?: number;
+    sourceAddrNpi?: number;
+    sourceAddr?: string;
+    destAddrTon?: number;
+    destAddrNpi?: number;
+    protocolId?: number;
+    priorityFlag?: PriorityFlag;
+    scheduleDeliveryTime?: string;
+    validityPeriod?: string;
+    registeredDelivery?: number;
+    replaceIfPresentFlag?: number;
+    smDefaultMsgId?: number;
+    smLength?: number;
+    shortMessage?: {
+        message: string;
+        encoding?: Encode;
+    };
+};
+
+export interface DeliverSmFunction extends DTOFunction<DeliverSmParams, DeliverSm> {
+    ({
+        destinationAddr,
+        dataCoding,
+        esmClass,
+        systemTypeValue,
+        sourceAddrTon,
+        sourceAddrNpi,
+        sourceAddr,
+        destAddrTon,
+        destAddrNpi,
+        protocolId,
+        priorityFlag,
+        scheduleDeliveryTime,
+        validityPeriod,
+        registeredDelivery,
+        replaceIfPresentFlag,
+        smDefaultMsgId,
+        smLength,
+        shortMessage,
+    }: DeliverSmParams): DeliverSm;
+}

--- a/src/types/dto/deliver_sm_resp.ts
+++ b/src/types/dto/deliver_sm_resp.ts
@@ -1,0 +1,15 @@
+import { DTO, DTOFunction } from '../index';
+
+export interface DeliverSmResp extends DTO {
+    command: {
+        message_id: { type: 'Cstring'; value: string };
+    };
+}
+
+export type DeliverSmRespParams = {
+    messageId?: string;
+};
+
+export interface DeliverSmRespFunction extends DTOFunction<DeliverSmRespParams, DeliverSmResp> {
+    ({ messageId }: DeliverSmRespParams): DeliverSmResp;
+}

--- a/src/types/dto/index.ts
+++ b/src/types/dto/index.ts
@@ -19,6 +19,7 @@ export * from './cancel_sm_resp';
 export * from './outbind';
 export * from './replace_sm';
 export * from './deliver_sm';
+export * from './deliver_sm_resp';
 
 export type DTO<
     T = {

--- a/src/types/dto/index.ts
+++ b/src/types/dto/index.ts
@@ -16,6 +16,7 @@ export * from './query_sm';
 export * from './query_sm_resp';
 export * from './cancel_sm';
 export * from './cancel_sm_resp';
+export * from './outbind';
 
 export type DTO<
     T = {

--- a/src/types/dto/index.ts
+++ b/src/types/dto/index.ts
@@ -18,6 +18,7 @@ export * from './cancel_sm';
 export * from './cancel_sm_resp';
 export * from './outbind';
 export * from './replace_sm';
+export * from './deliver_sm';
 
 export type DTO<
     T = {

--- a/src/types/dto/index.ts
+++ b/src/types/dto/index.ts
@@ -17,6 +17,7 @@ export * from './query_sm_resp';
 export * from './cancel_sm';
 export * from './cancel_sm_resp';
 export * from './outbind';
+export * from './replace_sm';
 
 export type DTO<
     T = {

--- a/src/types/dto/index.ts
+++ b/src/types/dto/index.ts
@@ -14,6 +14,8 @@ export * from './data_sm';
 export * from './data_sm_resp';
 export * from './query_sm';
 export * from './query_sm_resp';
+export * from './cancel_sm';
+export * from './cancel_sm_resp';
 
 export type DTO<
     T = {

--- a/src/types/dto/outbind.ts
+++ b/src/types/dto/outbind.ts
@@ -1,0 +1,17 @@
+import { DTO, DTOFunction } from '../index';
+
+export interface Outbind extends DTO {
+    command: {
+        system_id: { type: 'Cstring'; value: string };
+        password: { type: 'Cstring'; value: string };
+    };
+}
+
+export type OutbindParams = {
+    systemId: string;
+    password: string;
+};
+
+export interface OutbindFunction extends DTOFunction<OutbindParams, Outbind> {
+    ({ systemId, password }: OutbindParams): Outbind;
+}

--- a/src/types/dto/replace_sm.ts
+++ b/src/types/dto/replace_sm.ts
@@ -1,0 +1,50 @@
+import { DTO, DTOFunction, Encode } from '../index';
+
+/**
+ * sm_length - Passed in short message DTO (setLength).
+ */
+export interface ReplaceSm extends DTO {
+    command: {
+        message_id: { type: 'Cstring'; value: string };
+        source_addr_ton: { type: 'Int8'; value: number };
+        source_addr_npi: { type: 'Int8'; value: number };
+        source_addr: { type: 'Cstring'; value: string };
+        schedule_delivery_time: { type: 'Cstring'; value: string };
+        validity_period: { type: 'Cstring'; value: string };
+        registered_delivery: { type: 'Int8'; value: number };
+        sm_default_msg_id: { type: 'Int8'; value: number };
+        /**
+         * Default ASCII
+         */
+        short_message: { type: 'Cstring'; value: string | Buffer; encode?: Encode; setLength?: boolean };
+    };
+}
+
+export type ReplaceSmParams = {
+    messageId: string;
+    sourceAddrTon?: number;
+    sourceAddrNpi?: number;
+    sourceAddr?: string;
+    scheduleDeliveryTime?: Date | string;
+    validityPeriod?: Date | string;
+    registeredDelivery?: number;
+    smDefaultMsgId?: number;
+    shortMessage?: {
+        message: string;
+        encoding?: Encode;
+    };
+};
+
+export interface ReplaceSmFunction extends DTOFunction<ReplaceSmParams, ReplaceSm> {
+    ({
+        messageId,
+        sourceAddrTon,
+        sourceAddrNpi,
+        sourceAddr,
+        scheduleDeliveryTime,
+        validityPeriod,
+        registeredDelivery,
+        smDefaultMsgId,
+        shortMessage,
+    }: ReplaceSmParams): ReplaceSm;
+}

--- a/src/types/pdu.ts
+++ b/src/types/pdu.ts
@@ -56,7 +56,8 @@ export type CommandClient =
     | 'cancel_sm_resp'
     | 'data_sm_resp'
     | 'replace_sm'
-    | 'deliver_sm';
+    | 'deliver_sm'
+    | 'deliver_sm_resp';
 
 /**
  * Send commands name

--- a/src/types/pdu.ts
+++ b/src/types/pdu.ts
@@ -44,12 +44,17 @@ export type CommandClient =
     | 'enquire_link'
     | 'data_sm'
     | 'query_sm'
+    | 'outbind'
+    | 'cancel_sm'
     | 'bind_receiver_resp'
     | 'bind_transmitter_resp'
+    | 'bind_transceiver_resp'
     | 'submit_sm_resp'
     | 'unbind_resp'
-    | 'bind_transceiver_resp'
-    | 'enquire_link_resp';
+    | 'enquire_link_resp'
+    | 'query_sm_resp'
+    | 'cancel_sm_resp'
+    | 'data_sm_resp';
 
 /**
  * Send commands name
@@ -65,7 +70,6 @@ export type SendCommandName =
     | 'replace_sm'
     | 'cancel_sm'
     | 'bind_transceiver'
-    | 'outbind'
     | 'enquire_link'
     | 'submit_multi'
     | 'alert_notification'
@@ -86,7 +90,8 @@ export type ResponseCommandName =
     | 'bind_transceiver_resp'
     | 'enquire_link_resp'
     | 'submit_multi_resp'
-    | 'data_sm_resp';
+    | 'data_sm_resp'
+    | 'outbind';
 
 /**
  * Pdu base object

--- a/src/types/pdu.ts
+++ b/src/types/pdu.ts
@@ -55,7 +55,8 @@ export type CommandClient =
     | 'query_sm_resp'
     | 'cancel_sm_resp'
     | 'data_sm_resp'
-    | 'replace_sm';
+    | 'replace_sm'
+    | 'deliver_sm';
 
 /**
  * Send commands name
@@ -66,7 +67,7 @@ export type SendCommandName =
     | 'bind_transmitter'
     | 'query_sm'
     | 'submit_sm'
-    | 'deliver_sm'
+    | 'deliver_sm_resp'
     | 'unbind'
     | 'replace_sm'
     | 'cancel_sm'
@@ -84,7 +85,6 @@ export type ResponseCommandName =
     | 'bind_transmitter_resp'
     | 'query_sm_resp'
     | 'submit_sm_resp'
-    | 'deliver_sm_resp'
     | 'unbind_resp'
     | 'replace_sm_resp'
     | 'cancel_sm_resp'
@@ -92,7 +92,8 @@ export type ResponseCommandName =
     | 'enquire_link_resp'
     | 'submit_multi_resp'
     | 'data_sm_resp'
-    | 'outbind';
+    | 'outbind'
+    | 'deliver_sm';
 
 /**
  * Pdu base object

--- a/src/types/pdu.ts
+++ b/src/types/pdu.ts
@@ -54,7 +54,8 @@ export type CommandClient =
     | 'enquire_link_resp'
     | 'query_sm_resp'
     | 'cancel_sm_resp'
-    | 'data_sm_resp';
+    | 'data_sm_resp'
+    | 'replace_sm';
 
 /**
  * Send commands name


### PR DESCRIPTION
- PDU Read
  - Added Int8 read
  - Now when using `read` and found a `data_coding` or `length` related to the message, it uses it as the basis for encoding and size.
- PDU
    - Cancel_sm and query_sm_resp created
    - Replace_sm and Replace_sm_resp created 
    - Deliver_sm_resp and deliver_sm created 
    - Outbind created 
- Encodes created
- Cstring, change read to accept encode and length 
